### PR TITLE
Fixes #2 Updates mashlib url and replaces $rdf SparQLUpdate

### DIFF
--- a/app-pad.js
+++ b/app-pad.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var ns = tabulator.ns;
     var dom = document;
     var me;
-    var updater = new $rdf.sparqlUpdate(kb);
+    var updater = kb.updater;
     var waitingForLogin = false;
 
     var ICAL = $rdf.Namespace('http://www.w3.org/2002/12/cal/ical#');
@@ -927,7 +927,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             showResults(false);
                         } else {
                             complainIfBad(ok, "FAILED to create results file at: "+ padDoc.uri +' : ' + message);
-                            console.log("FAILED to craete results file at: "+ padDoc.uri +' : ' + message);
+                            console.log("FAILED to create results file at: "+ padDoc.uri +' : ' + message);
                         };
                     });
                 } else { // Other error, not 404 -- do not try to overwite the file

--- a/index.html
+++ b/index.html
@@ -19,10 +19,13 @@ tr.naviMenu  { background-color: white;}
 tr.naviMenu td { text-align: middle; vertical-align: middle; padding-top: 4em; };
 
 </style>
-<!--
+
 <script type="text/javascript" src="https://linkeddata.github.io/tabulator/js/mashup/mashlib.js"></script>
--->
+
+<!--
 <script type="text/javascript" src="https://timbl.com/timbl/Automation/Library/Mashup/mashlib-alpha.js"></script>
+-->
+
 <script type="text/javascript" src="app-pad.js"></script>
 
 


### PR DESCRIPTION
- `$rdf.sparqlUpdate()` is not a constructor and has been removed in latest update.
- `tabulator.kb.updater` contains the required updater.
- Fixes a typo in error logging.
- Updates the URL needed for `mashlib.js`